### PR TITLE
fix: 修复再次加载菜单权限时未能选中已保存菜单项错误

### DIFF
--- a/apps/web-antd/src/views/system/role/modules/assign-menu-form.vue
+++ b/apps/web-antd/src/views/system/role/modules/assign-menu-form.vue
@@ -72,13 +72,14 @@ const [Modal, modalApi] = useVbenModal({
     }
     modalApi.lock();
     try {
-      // 加载角色菜单
-      const menuIds = await getRoleMenuList(data.id as number);
-      await formApi.setFieldValue('menuIds', menuIds);
       // 加载菜单列表
       await loadMenuTree();
 
       await formApi.setValues(data);
+      
+      // 加载角色菜单
+      const menuIds = await getRoleMenuList(data.id as number);
+      await formApi.setFieldValue('menuIds', menuIds);      
     } finally {
       modalApi.unlock();
     }


### PR DESCRIPTION
## Description

- 由于未能先加载全部菜单再去设置已勾选的菜单，导致重新打开菜单权限时未能显示之前已选中的菜单项

## Type of change

Please delete options that are not relevant.

- [✓] Bug fix (non-breaking change which fixes an issue)

## Checklist

> ℹ️ Check all checkboxes - this will indicate that you have done everything in accordance with the rules in [CONTRIBUTING](contributing.md).

- [✓] If you introduce new functionality, document it. You can run documentation with `pnpm run docs:dev` command.
- [✓] Run the tests with `pnpm test`.
- [✓] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
- [✓] My code follows the style guidelines of this project
- [✓] I have performed a self-review of my own code
- [✓] I have commented my code, particularly in hard-to-understand areas
- [✓] I have made corresponding changes to the documentation
- [✓] My changes generate no new warnings
- [✓] I have added tests that prove my fix is effective or that my feature works
- [✓] New and existing unit tests pass locally with my changes
- [✓] Any dependent changes have been merged and published in downstream modules
