### PR TITLE
fix: [bpm][antd&ele] 修复流程设计器自定义配置编辑后丢失的问题

### DIFF
--- a/apps/web-antd/src/views/bpm/components/bpmn-process-designer/package/penal/custom-config/components/UserTaskCustomConfig.vue
+++ b/apps/web-antd/src/views/bpm/components/bpmn-process-designer/package/penal/custom-config/components/UserTaskCustomConfig.vue
@@ -175,7 +175,7 @@ const resetCustomConfigList = () => {
   approveType.value =
     elExtensionElements.value.values?.find(
       (ex: any) => ex.$type === `${prefix}:ApproveType`,
-    )?.[0] ||
+    ) ||
     bpmnInstances().moddle.create(`${prefix}:ApproveType`, {
       value: ApproveType.USER,
     });
@@ -184,7 +184,7 @@ const resetCustomConfigList = () => {
   assignStartUserHandlerTypeEl.value =
     elExtensionElements.value.values?.find(
       (ex: any) => ex.$type === `${prefix}:AssignStartUserHandlerType`,
-    )?.[0] ||
+    ) ||
     bpmnInstances().moddle.create(`${prefix}:AssignStartUserHandlerType`, {
       value: 1,
     });
@@ -194,13 +194,13 @@ const resetCustomConfigList = () => {
   rejectHandlerTypeEl.value =
     elExtensionElements.value.values?.find(
       (ex: any) => ex.$type === `${prefix}:RejectHandlerType`,
-    )?.[0] ||
+    ) ||
     bpmnInstances().moddle.create(`${prefix}:RejectHandlerType`, { value: 1 });
   rejectHandlerType.value = rejectHandlerTypeEl.value.value;
   returnNodeIdEl.value =
     elExtensionElements.value.values?.find(
       (ex: any) => ex.$type === `${prefix}:RejectReturnTaskId`,
-    )?.[0] ||
+    ) ||
     bpmnInstances().moddle.create(`${prefix}:RejectReturnTaskId`, {
       value: '',
     });
@@ -210,7 +210,7 @@ const resetCustomConfigList = () => {
   assignEmptyHandlerTypeEl.value =
     elExtensionElements.value.values?.find(
       (ex: any) => ex.$type === `${prefix}:AssignEmptyHandlerType`,
-    )?.[0] ||
+    ) ||
     bpmnInstances().moddle.create(`${prefix}:AssignEmptyHandlerType`, {
       value: 1,
     });
@@ -218,7 +218,7 @@ const resetCustomConfigList = () => {
   assignEmptyUserIdsEl.value =
     elExtensionElements.value.values?.find(
       (ex: any) => ex.$type === `${prefix}:AssignEmptyUserIds`,
-    )?.[0] ||
+    ) ||
     bpmnInstances().moddle.create(`${prefix}:AssignEmptyUserIds`, {
       value: '',
     });

--- a/apps/web-ele/src/views/bpm/components/bpmn-process-designer/package/penal/custom-config/components/UserTaskCustomConfig.vue
+++ b/apps/web-ele/src/views/bpm/components/bpmn-process-designer/package/penal/custom-config/components/UserTaskCustomConfig.vue
@@ -164,7 +164,7 @@ const resetCustomConfigList = () => {
   approveType.value =
     elExtensionElements.value.values?.find(
       (ex: any) => ex.$type === `${prefix}:ApproveType`,
-    )?.[0] ||
+    ) ||
     bpmnInstances().moddle.create(`${prefix}:ApproveType`, {
       value: ApproveType.USER,
     });
@@ -173,7 +173,7 @@ const resetCustomConfigList = () => {
   assignStartUserHandlerTypeEl.value =
     elExtensionElements.value.values?.find(
       (ex: any) => ex.$type === `${prefix}:AssignStartUserHandlerType`,
-    )?.[0] ||
+    ) ||
     bpmnInstances().moddle.create(`${prefix}:AssignStartUserHandlerType`, {
       value: 1,
     });
@@ -183,13 +183,13 @@ const resetCustomConfigList = () => {
   rejectHandlerTypeEl.value =
     elExtensionElements.value.values?.find(
       (ex: any) => ex.$type === `${prefix}:RejectHandlerType`,
-    )?.[0] ||
+    ) ||
     bpmnInstances().moddle.create(`${prefix}:RejectHandlerType`, { value: 1 });
   rejectHandlerType.value = rejectHandlerTypeEl.value.value;
   returnNodeIdEl.value =
     elExtensionElements.value.values?.find(
       (ex: any) => ex.$type === `${prefix}:RejectReturnTaskId`,
-    )?.[0] ||
+    ) ||
     bpmnInstances().moddle.create(`${prefix}:RejectReturnTaskId`, {
       value: '',
     });
@@ -199,7 +199,7 @@ const resetCustomConfigList = () => {
   assignEmptyHandlerTypeEl.value =
     elExtensionElements.value.values?.find(
       (ex: any) => ex.$type === `${prefix}:AssignEmptyHandlerType`,
-    )?.[0] ||
+    ) ||
     bpmnInstances().moddle.create(`${prefix}:AssignEmptyHandlerType`, {
       value: 1,
     });
@@ -207,7 +207,7 @@ const resetCustomConfigList = () => {
   assignEmptyUserIdsEl.value =
     elExtensionElements.value.values?.find(
       (ex: any) => ex.$type === `${prefix}:AssignEmptyUserIds`,
-    )?.[0] ||
+    ) ||
     bpmnInstances().moddle.create(`${prefix}:AssignEmptyUserIds`, {
       value: '',
     });


### PR DESCRIPTION
## Description

现有的bpmn设计器打开审批节点，编辑自定义配置后，点击空白处/其他节点后。之前编辑的内容丢失了。
经过排查发现是点击审批节点刷新自定义配置时，find语法后接了数组取值[0]（find拿到的是单个元素），语法错误导致拿不到配置，导致每次都取默认值
<img width="2374" height="1030" alt="image" src="https://github.com/user-attachments/assets/649993f1-cc73-4b56-939b-98d322f9f216" />

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

> ℹ️ Check all checkboxes - this will indicate that you have done everything in accordance with the rules in [CONTRIBUTING](contributing.md).

- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs:dev` command.
- [ ] Run the tests with `pnpm test`.
- [ ] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
