### PR TITLE
perf(@vben-core/ui): 将菜单批量授权复杂度从 O(n²) 优化至 O(n)

### DIFF
--- a/packages/@core/ui-kit/shadcn-ui/src/ui/tree/tree.vue
+++ b/packages/@core/ui-kit/shadcn-ui/src/ui/tree/tree.vue
@@ -6,7 +6,7 @@ import type { ClassType, Recordable } from '@vben-core/typings';
 
 import type { TreeProps } from './types';
 
-import { computed, onMounted, ref, watchEffect } from 'vue';
+import { computed, ref, shallowRef, watch } from 'vue';
 
 import { ChevronRight, IconifyIcon } from '@vben-core/icons';
 import { cn, get } from '@vben-core/shared/utils';
@@ -60,38 +60,36 @@ function flatten<T = Recordable<any>, P = number | string>(
   return result;
 }
 
-const flattenData = ref<Array<InnerFlattenItem>>([]);
+const flattenData = shallowRef<Array<InnerFlattenItem>>([]);
+const itemByValue = shallowRef(new Map<number | string, Recordable<any>>());
 const modelValue = defineModel<Arrayable<number | string>>();
 const expanded = ref<Array<number | string>>(props.defaultExpandedKeys ?? []);
 
 const treeValue = ref();
-let lastTreeData: any = null;
 
-onMounted(() => {
-  watchEffect(() => {
-    flattenData.value = flatten(props.treeData, props.childrenField);
-    if (flattenData.value.length > 0) {
-      updateTreeValue();
-    }
+watch(
+  [() => props.treeData, () => props.childrenField, () => props.valueField],
+  () => {
+    const flattened = flatten(props.treeData, props.childrenField);
+    flattenData.value = flattened;
+    itemByValue.value = new Map(flattened.map((item) => [item.id, item.value]));
+    updateTreeValue();
 
-    // 只在 treeData 变化时执行展开
-    const currentTreeData = JSON.stringify(props.treeData);
-    if (lastTreeData !== currentTreeData) {
-      lastTreeData = currentTreeData;
-      if (
-        props.defaultExpandedLevel !== undefined &&
-        props.defaultExpandedLevel > 0
-      ) {
-        expandToLevel(props.defaultExpandedLevel);
-      }
+    // 只在树数据变化时计算默认展开节点，避免选中值变化时重复遍历。
+    if (
+      props.defaultExpandedLevel !== undefined &&
+      props.defaultExpandedLevel > 0
+    ) {
+      expandToLevel(props.defaultExpandedLevel);
     }
-  });
-});
+  },
+  { deep: true, immediate: true },
+);
+
+watch(modelValue, updateTreeValue, { deep: true, immediate: true });
 
 function getItemByValue(value: number | string) {
-  return flattenData.value.find(
-    (item) => get(item.value, props.valueField) === value,
-  )?.value;
+  return itemByValue.value.get(value);
 }
 
 function updateTreeValue() {
@@ -102,11 +100,16 @@ function updateTreeValue() {
     if (val.length === 0) {
       treeValue.value = [];
     } else {
-      const filteredValues = val.filter((v) => {
-        const item = getItemByValue(v);
-        return item && !get(item, props.disabledField);
-      });
-      treeValue.value = filteredValues.map((v) => getItemByValue(v));
+      const filteredValues: Array<number | string> = [];
+      const selectedItems: Recordable<any>[] = [];
+      for (const value of val) {
+        const item = getItemByValue(value);
+        if (item && !get(item, props.disabledField)) {
+          filteredValues.push(value);
+          selectedItems.push(item);
+        }
+      }
+      treeValue.value = selectedItems;
 
       if (filteredValues.length !== val.length) {
         modelValue.value = filteredValues;
@@ -199,12 +202,13 @@ const selectAllStatus = computed<'indeterminate' | boolean>(() => {
   if (!props.multiple) return false;
   if (!modelValue.value || !Array.isArray(modelValue.value)) return false;
 
+  const selectedValues = new Set(modelValue.value);
   const allValues = flattenData.value
     .filter((item) => !get(item.value, props.disabledField))
     .map((item) => get(item.value, props.valueField));
 
-  const selectedCount = allValues.filter((v) =>
-    (modelValue.value as (number | string)[]).includes(v),
+  const selectedCount = allValues.filter((value) =>
+    selectedValues.has(value),
   ).length;
 
   if (selectedCount === 0) return false;

--- a/packages/effects/common-ui/src/components/tree/__tests__/tree.test.ts
+++ b/packages/effects/common-ui/src/components/tree/__tests__/tree.test.ts
@@ -6,6 +6,48 @@ import { describe, expect, it } from 'vitest';
 import Tree from '../tree.vue';
 
 describe('tree', () => {
+  it('updates bulk selections after the tree data changes', async () => {
+    const treeData = ref([
+      {
+        id: 1,
+        name: 'parent',
+        children: [
+          { id: 2, name: 'child-2' },
+          { id: 3, name: 'child-3' },
+        ],
+      },
+    ]);
+    const selected = ref<number[]>([]);
+
+    const wrapper = mount(
+      defineComponent({
+        setup() {
+          return () =>
+            h(Tree, {
+              defaultExpandedKeys: [1],
+              labelField: 'name',
+              modelValue: selected.value,
+              multiple: true,
+              'onUpdate:modelValue': (value: number[]) => {
+                selected.value = value;
+              },
+              treeData: treeData.value,
+              valueField: 'id',
+            });
+        },
+      }),
+    );
+
+    selected.value = [1, 2, 3];
+    await nextTick();
+    expect(wrapper.findAll('.tree-node[data-selected]')).toHaveLength(3);
+
+    treeData.value[0]!.children.push({ id: 4, name: 'child-4' });
+    selected.value = [1, 2, 3, 4];
+    await nextTick();
+    expect(wrapper.findAll('.tree-node[data-selected]')).toHaveLength(4);
+  });
+
   it('deduplicates descendants when selecting a half-selected parent', async () => {
     const treeData = [
       {


### PR DESCRIPTION
## 变更说明

优化 `Tree` 组件在菜单权限批量选择、权限回显和全选状态计算时的性能，将主要处理流程的时间复杂度从 **O(n²) 降低至 O(n)**。

## 性能问题

原实现存在多处嵌套线性查找：

- 遍历选中值时，通过 `Array.find` 在全部菜单节点中查找对应节点。
- 计算全选状态时，对每个菜单节点调用 `Array.includes` 查找选中值。
- 选中值变化会触发整棵菜单树重新扁平化及 `JSON.stringify`。

当菜单节点数和选中节点数均接近 `n` 时，批量授权和权限回显的时间复杂度会达到 **O(n²)**，大型菜单树下会出现明显延迟。

## 优化方案

- 使用 `Map` 建立菜单 ID 到节点的索引：
  - 构建索引为 O(n)。
  - 单个节点查找由 O(n) 降至 O(1)。
  - 批量权限回显由 O(n²) 降至 O(n)。
- 使用 `Set` 保存已选菜单 ID：
  - 单次选中状态查询由 O(n) 降至 O(1)。
  - 全选、半选状态计算由 O(n²) 降至 O(n)。
- 分离菜单树数据和选中值的监听：
  - 仅在树数据变化时重新扁平化菜单树。
  - 选中值变化时只更新选中节点。
- 移除基于 `JSON.stringify` 的树数据变化检测。
- 使用 `shallowRef` 减少大型树数据不必要的深层响应式开销。

## 复杂度对比

| 场景 | 优化前 | 优化后 |
| --- | ---: | ---: |
| 批量权限回显 | O(n²) | O(n) |
| 全选/半选状态计算 | O(n²) | O(n) |
| 菜单 ID 节点查找 | O(n) | O(1) |
| 树索引构建 | — | O(n) |

## 测试

新增回归测试，覆盖菜单树数据动态变化后的批量选中状态同步，并保留原有半选父节点及子节点去重测试。

验证结果：

- Tree 组件测试通过（2/2）
- TypeScript 类型检查通过
- ESLint、Oxlint、Stylelint 和格式检查通过