### PR TITLE
fix(@vben/plugins): 修复 defaultSort 首次查询失效

### DIFF
--- a/packages/effects/plugins/src/vxe-table/use-vxe-grid.vue
+++ b/packages/effects/plugins/src/vxe-table/use-vxe-grid.vue
@@ -205,14 +205,17 @@ const toolbarOptions = computed(() => {
 const options = computed(() => {
   const globalGridConfig = VxeUI?.getConfig()?.grid ?? {};
 
-  const mergedOptions: VxeTableGridProps = cloneDeep(
-    mergeWithArrayOverride(
-      {},
-      toRaw(toolbarOptions.value),
-      toRaw(gridOptions.value),
-      globalGridConfig,
-    ),
+  const rawMergedOptions: VxeTableGridProps = mergeWithArrayOverride(
+    {},
+    toRaw(toolbarOptions.value),
+    toRaw(gridOptions.value),
+    globalGridConfig,
   );
+  const mergedOptions: VxeTableGridProps = cloneDeep(rawMergedOptions);
+
+  // VXE 会在 columns 引用变化时重新加载列；保持来源数组的引用稳定，避免
+  // 响应式配置更新时清空排序、筛选等内部列状态。
+  mergedOptions.columns = rawMergedOptions.columns;
 
   if (mergedOptions.proxyConfig) {
     const { ajax } = mergedOptions.proxyConfig;
@@ -331,17 +334,6 @@ async function init() {
     toRaw(gridOptions.value),
     toRaw(globalGridConfig),
   );
-  // 内部主动加载数据，防止form的默认值影响
-  const autoLoad = defaultGridOptions.proxyConfig?.autoLoad;
-  const enableProxyConfig = options.value.proxyConfig?.enabled;
-  if (enableProxyConfig && autoLoad) {
-    props.api.grid.commitProxy?.(
-      'query',
-      formOptions.value ? ((await formApi.getValues()) ?? {}) : {},
-    );
-    // props.api.reload(formApi.form?.values ?? {});
-  }
-
   // form 由 vben-form代替，所以不适配formConfig，这里给出警告
   const formConfig = gridOptions.value?.formConfig;
   // 处理某个页面加载多个Table时，第2个之后的Table初始化报出警告
@@ -356,6 +348,20 @@ async function init() {
   extendProxyOptions(props.api, defaultGridOptions, () =>
     formApi.getLatestSubmissionValues(),
   );
+
+  // 状态写回会触发 VXE 重新加载 columns，需等待列稳定后再应用 defaultSort。
+  await nextTick();
+
+  // 内部主动加载数据，防止 form 的默认值影响
+  const autoLoad = defaultGridOptions.proxyConfig?.autoLoad;
+  const enableProxyConfig = options.value.proxyConfig?.enabled;
+  if (enableProxyConfig && autoLoad) {
+    props.api.grid.commitProxy?.(
+      // initial 会应用 defaultSort，并将排序状态传给首次代理查询
+      'initial',
+      formOptions.value ? ((await formApi.getValues()) ?? {}) : {},
+    );
+  }
 }
 
 // formOptions支持响应式


### PR DESCRIPTION
## Description

当 VxeGrid 同时配置 `proxyConfig.autoLoad`、远程排序和 `sortConfig.defaultSort` 时，封装组件会关闭 VXE 内置自动加载并手动执行 `commitProxy('query')`。普通 `query` 不会应用 `defaultSort`，导致首次代理请求中的 `sort` / `sorts` 为空。

此外，当前 `cloneDeep` 会在响应式配置更新时生成新的 `columns` 数组；VXE 监听该引用并重新加载列，排序、筛选等内部列状态会被清空。

本次调整：

- 深拷贝其他表格配置时保留 `columns` 的稳定引用；
- 先完成 Grid 状态写回和代理参数扩展，再等待列加载稳定；
- 首次自动查询改为 `commitProxy('initial')`，让 VXE 应用 `defaultSort` 并把排序参数传给第一次请求。

## Reproduction

1. 为可排序列配置 `sortConfig.defaultSort` 与 `remote: true`；
2. 开启 `proxyConfig.sort` / `autoLoad`，在 `ajax.query` 中读取 `sort` 或 `sorts`；
3. 修改前首次请求没有默认排序参数；修改后首次请求包含配置的字段和顺序，列状态在响应式更新后也能保持。

## Related issues

- https://github.com/vbenjs/vue-vben-admin/issues/5125
- https://github.com/vbenjs/vue-vben-admin/issues/6954

## Validation

- [x] `pnpm exec oxfmt --check packages/effects/plugins/src/vxe-table/use-vxe-grid.vue`
- [x] `pnpm exec eslint packages/effects/plugins/src/vxe-table/use-vxe-grid.vue`
- [x] Commitlint
- [x] No changes to `pnpm-lock.yaml`
- [ ] `pnpm test:unit`: 329 tests passed; 1 unrelated existing failure in `packages/stores/src/modules/user.test.ts`
